### PR TITLE
Add metadata tools for Pitágoras

### DIFF
--- a/pitagoras/api.py
+++ b/pitagoras/api.py
@@ -223,3 +223,90 @@ async def get_google_analytics_report(
         except Exception as e:
             logger.error(f"Unexpected error with Google Analytics API: {str(e)}", exc_info=True)
             raise Exception(f"Error con la API de Google Analytics: {str(e)}") from e
+
+
+async def get_analytics4_metadata(
+    property_id: str = "0", credential_email: str = "analytics@epa.digital"
+) -> Dict[str, Any]:
+    """Get available GA4 dimensions and metrics"""
+    payload = {"property_id": property_id, "credential_email": credential_email}
+
+    async with httpx.AsyncClient() as client:
+        headers = {}
+        if AUTH_TOKEN:
+            headers["Authorization"] = AUTH_TOKEN
+
+        response = await client.post(
+            ENDPOINTS["analytics4_metadata"], json=payload, headers=headers
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+async def get_facebook_schema() -> Dict[str, Any]:
+    """Get Facebook Ads available fields"""
+    async with httpx.AsyncClient() as client:
+        headers = {}
+        if AUTH_TOKEN:
+            headers["Authorization"] = AUTH_TOKEN
+
+        response = await client.get(ENDPOINTS["facebook_schema"], headers=headers)
+        response.raise_for_status()
+        return response.json()
+
+
+async def get_adwords_resources() -> List[str]:
+    """List available Google Ads resources"""
+    async with httpx.AsyncClient() as client:
+        headers = {}
+        if AUTH_TOKEN:
+            headers["Authorization"] = AUTH_TOKEN
+
+        response = await client.get(ENDPOINTS["adwords_resources"], headers=headers)
+        response.raise_for_status()
+        return response.json()
+
+
+async def get_adwords_attributes(resource_name: str) -> List[str]:
+    """Get Google Ads attributes for a resource"""
+    params = {"resource_name": resource_name}
+    async with httpx.AsyncClient() as client:
+        headers = {}
+        if AUTH_TOKEN:
+            headers["Authorization"] = AUTH_TOKEN
+
+        response = await client.get(
+            ENDPOINTS["adwords_attributes"], params=params, headers=headers
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+async def get_adwords_segments(resource_name: str) -> List[str]:
+    """Get Google Ads segments for a resource"""
+    params = {"resource_name": resource_name}
+    async with httpx.AsyncClient() as client:
+        headers = {}
+        if AUTH_TOKEN:
+            headers["Authorization"] = AUTH_TOKEN
+
+        response = await client.get(
+            ENDPOINTS["adwords_segments"], params=params, headers=headers
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+async def get_adwords_metrics(resource_name: str) -> List[str]:
+    """Get Google Ads metrics for a resource"""
+    params = {"resource_name": resource_name}
+    async with httpx.AsyncClient() as client:
+        headers = {}
+        if AUTH_TOKEN:
+            headers["Authorization"] = AUTH_TOKEN
+
+        response = await client.get(
+            ENDPOINTS["adwords_metrics"], params=params, headers=headers
+        )
+        response.raise_for_status()
+        return response.json()

--- a/pitagoras/config.py
+++ b/pitagoras/config.py
@@ -16,4 +16,10 @@ ENDPOINTS = {
     "google_ads": f"{BASE_URL}/adwords/report",
     "facebook_ads": f"{BASE_URL}/facebook/report",
     "google_analytics": f"{BASE_URL}/analytics4/report",
+    "analytics4_metadata": f"{BASE_URL}/analytics4/metadata",
+    "facebook_schema": f"{BASE_URL}/facebook/schema",
+    "adwords_resources": f"{BASE_URL}/adwords/resources",
+    "adwords_attributes": f"{BASE_URL}/adwords/attributes",
+    "adwords_segments": f"{BASE_URL}/adwords/segments",
+    "adwords_metrics": f"{BASE_URL}/adwords/metrics",
 }

--- a/server/prompts.py
+++ b/server/prompts.py
@@ -77,7 +77,12 @@ async def register_prompts(mcp: FastMCP):
             - Fecha inicial: YYYY-MM-DD (Ej: 2025-01-01)
             - Fecha final: YYYY-MM-DD (Ej: 2025-04-30)
             - Períodos predefinidos: "Último mes", "Último trimestre", "Año actual"
-            
+
+            ## Consulta del esquema de Google Ads
+            Antes de solicitar las métricas puedo mostrarte las opciones reales.
+            Ejecutaré las herramientas `adwords_resources`, `adwords_attributes('campaign')`,
+            `adwords_segments('campaign')` y `adwords_metrics('campaign')` para
+            obtener sugerencias basadas en el recurso `campaign`.
             ## Métricas (opcional):
             Si no especificas métricas, usaré las predeterminadas (costo, impresiones, clics).
             Para personalizar, indica exactamente cuáles necesitas:
@@ -121,7 +126,11 @@ async def register_prompts(mcp: FastMCP):
             - Fecha inicial: YYYY-MM-DD (Ej: 2025-01-01)
             - Fecha final: YYYY-MM-DD (Ej: 2025-04-30)
             - Períodos predefinidos: "Último mes", "Último trimestre", "Año actual"
-            
+
+            ## Consulta del esquema de Facebook Ads
+            Antes de definir los campos ejecutaré la herramienta `facebook_schema`
+            para mostrarte los nombres y tipos disponibles.
+
             ## Campos (opcional):
             Si no especificas campos, usaré los predeterminados (campaign_name, date_start, spend, impressions, clicks).
             Para personalizar, indica exactamente cuáles necesitas:
@@ -168,6 +177,10 @@ async def register_prompts(mcp: FastMCP):
             - Fecha inicial: YYYY-MM-DD (Ej: 2025-01-01)
             - Fecha final: YYYY-MM-DD (Ej: 2025-04-30)
             - O usa períodos predefinidos: "Último mes", "Último trimestre", "Año actual"
+
+            ## Consulta de metadatos de GA4
+            Antes de elegir dimensiones o métricas, ejecutaré la herramienta `analytics4_metadata`
+            para mostrarte las opciones disponibles.
             
             ## Parámetros opcionales:
             1. **Dimensiones** (opcional):

--- a/server/tools.py
+++ b/server/tools.py
@@ -7,7 +7,13 @@ from pitagoras.api import (
     get_customers,
     get_google_ads_report,
     get_facebook_ads_report,
-    get_google_analytics_report
+    get_google_analytics_report,
+    get_analytics4_metadata,
+    get_facebook_schema,
+    get_adwords_resources,
+    get_adwords_attributes,
+    get_adwords_segments,
+    get_adwords_metrics,
 )
 
 # Configurar logging para escribir en stderr (que MCP captura automáticamente)
@@ -530,5 +536,109 @@ async def register_tools(mcp: FastMCP):
         result.append("- `all`: Seleccionar todas las cuentas disponibles")
         result.append("- `[número]`: Seleccionar por número de la tabla (ej: `1,3,5`)")
         result.append("- `id:[ID]`: Seleccionar por ID específico (ej: `id:123456789,id:987654321`)")
-        
+
+        return "\n".join(result)
+
+    @mcp.tool()
+    async def analytics4_metadata() -> str:
+        """Show available GA4 dimensions and metrics"""
+        try:
+            metadata = await get_analytics4_metadata()
+        except Exception as e:
+            return f"Error al obtener metadata de GA4: {str(e)}"
+
+        result = ["# Metadata de Google Analytics 4"]
+        dims = metadata.get("dimensions", [])
+        if dims:
+            result.append("## Dimensiones")
+            result.append("| Valor | Etiqueta |")
+            result.append("| --- | --- |")
+            for dim in dims:
+                result.append(f"| {dim.get('value')} | {dim.get('label', '')} |")
+
+        mets = metadata.get("metrics", [])
+        if mets:
+            result.append("\n## Métricas")
+            result.append("| Valor | Etiqueta |")
+            result.append("| --- | --- |")
+            for met in mets:
+                result.append(f"| {met.get('value')} | {met.get('label', '')} |")
+
+        return "\n".join(result)
+
+    @mcp.tool()
+    async def facebook_schema() -> str:
+        """Display Facebook Ads fields schema"""
+        try:
+            data = await get_facebook_schema()
+        except Exception as e:
+            return f"Error al obtener esquema de Facebook Ads: {str(e)}"
+
+        fields = data.get("fields", [])
+        if not fields:
+            return "No se encontraron campos disponibles"
+
+        result = ["# Esquema de Facebook Ads", "| Campo | Tipo |", "| --- | --- |"]
+        for field in fields:
+            result.append(f"| {field.get('name')} | {field.get('type', '')} |")
+        return "\n".join(result)
+
+    @mcp.tool()
+    async def adwords_resources() -> str:
+        """List Google Ads resources"""
+        try:
+            resources = await get_adwords_resources()
+        except Exception as e:
+            return f"Error al obtener recursos de Google Ads: {str(e)}"
+
+        if not resources:
+            return "No se encontraron recursos disponibles"
+
+        result = ["# Recursos de Google Ads"]
+        result.extend(f"- {r}" for r in resources)
+        return "\n".join(result)
+
+    @mcp.tool()
+    async def adwords_attributes(resource_name: str) -> str:
+        """List attributes for a Google Ads resource"""
+        try:
+            attrs = await get_adwords_attributes(resource_name)
+        except Exception as e:
+            return f"Error al obtener atributos: {str(e)}"
+
+        if not attrs:
+            return f"No se encontraron atributos para {resource_name}"
+
+        result = [f"# Atributos para {resource_name}"]
+        result.extend(f"- {a}" for a in attrs)
+        return "\n".join(result)
+
+    @mcp.tool()
+    async def adwords_segments(resource_name: str) -> str:
+        """List segments for a Google Ads resource"""
+        try:
+            segs = await get_adwords_segments(resource_name)
+        except Exception as e:
+            return f"Error al obtener segmentos: {str(e)}"
+
+        if not segs:
+            return f"No se encontraron segmentos para {resource_name}"
+
+        result = [f"# Segmentos para {resource_name}"]
+        result.extend(f"- {s}" for s in segs)
+        return "\n".join(result)
+
+    @mcp.tool()
+    async def adwords_metrics(resource_name: str) -> str:
+        """List metrics for a Google Ads resource"""
+        try:
+            mets = await get_adwords_metrics(resource_name)
+        except Exception as e:
+            return f"Error al obtener métricas: {str(e)}"
+
+        if not mets:
+            return f"No se encontraron métricas para {resource_name}"
+
+        result = [f"# Métricas para {resource_name}"]
+        result.extend(f"- {m}" for m in mets)
         return "\n".join(result)


### PR DESCRIPTION
## Summary
- expand API wrapper with metadata retrieval functions
- register new tools that expose schema/metadata information
- extend prompts to mention new tools for suggestions
- update configuration with new API endpoints

## Testing
- `python -m py_compile pitagoras/api.py pitagoras/config.py server/tools.py server/prompts.py`